### PR TITLE
Bæta við röðum fyrir smit innanlands og erlendis

### DIFF
--- a/covid-19-is-sitrep.csv
+++ b/covid-19-is-sitrep.csv
@@ -10,30 +10,38 @@ Dagsetning,Mæling,Gildi
 2020-02-24,Rannsökuð frá upphafi,33
 2020-02-25,Rannsökuð frá upphafi,35
 2020-02-26,Rannsökuð frá upphafi,38
+2020-02-27,Smit innanlands,0
+2020-02-27,Smit erlendis,0
 2020-02-27,Smit alls,0
 2020-02-27,Einangrun,0
 2020-02-27,Sóttkví alls,0
 2020-02-27,Rannsökuð frá upphafi,46
+2020-03-02,Smit innanlands,0
+2020-03-02,Smit erlendis,6
 2020-03-02,Smit alls,6
 2020-03-02,Einangrun,6
 2020-03-02,Sóttkví alls,260
 2020-03-02,Greind,3
 2020-03-02,Rannsökuð sýni,19
 2020-03-02,Rannsökuð frá upphafi,150
+2020-03-03,Smit innanlands,0
+2020-03-03,Smit erlendis,14
 2020-03-03,Smit alls,14
 2020-03-03,Einangrun,14
 2020-03-03,Sóttkví alls,300
 2020-03-03,Greind,2
 2020-03-03,Rannsökuð sýni,29
 2020-03-03,Rannsökuð frá upphafi,180
+2020-03-04,Smit innanlands,0
+2020-03-04,Smit erlendis,26
 2020-03-04,Smit alls,26
 2020-03-04,Einangrun,26
 2020-03-04,Sóttkví alls,380
 2020-03-04,Greind,10
 2020-03-04,Rannsökuð sýni,50
 2020-03-04,Rannsökuð frá upphafi,230
-2020-03-05,Smit innanlands,
-2020-03-05,Smit erlendis,
+2020-03-05,Smit innanlands,0
+2020-03-05,Smit erlendis,35
 2020-03-05,Smit alls,35
 2020-03-05,Einangrun,35
 2020-03-05,Sóttkví alls,400


### PR DESCRIPTION
Í stöðuskýrslum frá Landlækni eru smit ekki tilgreind sem innanlands eða erlendis fyrr en 6. mars 2020 þegar fyrstu innanlandssmitin greinast. Öll smit alls eru því erlend smit að 6. mars. Hér er bætt við röðum fyrir smit innanlands og smit erlendis fyrir 6. mars.